### PR TITLE
gem5 fast compatibility 

### DIFF
--- a/src/cpu/io/commit.cc
+++ b/src/cpu/io/commit.cc
@@ -93,11 +93,14 @@ Commit::doCommit()
   // commit.
   while (!m_insts.empty()) {
     IODynInstPtr inst = m_insts.front();
+
+    #ifndef NDEBUG
     ThreadID tid = inst->thread_id;
 
     // assert inst exists in ROB
     assert(m_robs[tid]->hasInst(inst));
     assert(!inst->isCommitted() && !inst->canCommit());
+    #endif
 
     // If this inst does not have any fault, mark it as "CanCommit".
     // Otherwise, mark it as "NeedToTrapFault"

--- a/src/cpu/io/decode.cc
+++ b/src/cpu/io/decode.cc
@@ -74,9 +74,12 @@ Decode::doDecode()
   // of credits to the next stage
   while (!m_insts.empty() && m_num_credits > 0) {
     IODynInstPtr inst = m_insts.front();
+
+    #ifndef NDEBUG
     ThreadID tid = inst->thread_id;
     DPRINTF(Decode, "[tid:%d] Decoding inst [sn:%lli] with PC %s\n",
                     tid, inst->seq_num, inst->pc);
+    #endif
 
     // send out this inst
     sendInstToNextStage(inst);

--- a/src/cpu/io/mem_unit.cc
+++ b/src/cpu/io/mem_unit.cc
@@ -454,6 +454,8 @@ MemUnit::doSquash(IODynInstPtr squash_inst)
                  [](const IODynInstPtr& inst) { return inst->isSquashed(); });
   m_st_queue.erase(st_it, m_st_queue.end());
 
+
+  #ifndef NDEBUG
   DPRINTF(LSQ, "Load queue after squashing ...\n");
   for (auto& inst : m_ld_queue)
     DPRINTF(LSQ, "\t%s\n", inst->toString());
@@ -461,6 +463,7 @@ MemUnit::doSquash(IODynInstPtr squash_inst)
   DPRINTF(LSQ, "Store queue after squashing ...\n");
   for (auto& inst : m_st_queue)
     DPRINTF(LSQ, "\t%s\n", inst->toString());
+  #endif
 
 #ifdef DEBUG
   m_status.set(Status::Squashed);

--- a/src/custom/mesh_helper.cc
+++ b/src/custom/mesh_helper.cc
@@ -191,6 +191,7 @@ MeshHelper::csrToInSrcs(uint64_t csr, uint64_t csrVal, std::vector<Mesh_Dir> &di
   }
   else {
     assert(0);
+    return false;
   }
 }
 
@@ -205,6 +206,7 @@ MeshHelper::csrToOutDests(uint64_t csr, uint64_t csrVal, std::vector<Mesh_Dir> &
   }
   else {
     assert(0);
+    return false;
   }
 }
 


### PR DESCRIPTION
Put in hash defines to allow gem5 fast to compile. Not really relevant to socket problem anymore. But might be useful during final eval to be able to simulate using gem5 fast.

Low priority.