### PR TITLE
Update test result for gluer

### DIFF
--- a/trillium/test/simple_scalar.out
+++ b/trillium/test/simple_scalar.out
@@ -2,32 +2,34 @@
 	SCALAR_HEADER
 	somefunc:
 	.insn i 0x77, 0, x0, a0, 0x401
-	SCALAR_FUNC_TOP
+	BEFORE_VECTOR_EPOCH
 .SCALAR1:
 	# trillium: scalar stack cleanup begin
+	SCALAR_STACK_CLEANUP
 	# trillium: scalar stack cleanup end
 	SCALAR_BEFORE_DEVEC
 	.insn uj 0x2b, x0, .SCALAR14
+.SCALAR2:
 	SCALAR_AFTER_DEVEC
 	ret
 	# trillium: auxiliary blocks begin
 .trillium_anon_aux_bb:
 	SCALAR_AFTER_RETURN
-	SCALAR_AFTER_GLUE_POINT
-	SCALAR_AFTER_ANOTHER_GLUE_POINT
+.SCALAR4:
+	AN_AUXILIARY_BLOCK
+.SCALAR6:
+	ANOTHER_AUXILIARY_BLOCK
 	# trillium: auxiliary blocks end
 	# trillium: vector vissue blocks begin
-.SCALAR2:  # block_one vissue block
+.SCALAR3:  # block_one vissue block
 	#prepended trillium_init block here (See docs for more info)
 	#trillium_init begin
-	VECTOR_BEFORE_BLOCK
+	TRILLIUM_INIT_BLOCK
 	#trillium_init end
 	VECTOR_BLOCK_ONE
 	.insn i 0x1b, 0x7, x0, x0, 0
-.SCALAR13:  # block_two vissue block
+.SCALAR5:  # block_two vissue block
 	VECTOR_BLOCK_TWO
-	.size whatever
-	VECTOR_FOOTER
 	.insn i 0x1b, 0x7, x0, x0, 0
 	# trillium: vector vissue blocks end
 	# trillium: footer begin


### PR DESCRIPTION
This just updates the expected output from the test updated in 381c73819bc7ea05a41d37b24029de4b41d1a383. As a reminder, the idea is to check in the expected output to the git repository so it's "locked in." When you change the input, you can automatically update the output like this:

    turnt --save test/*_scalar.s
