### PR TITLE
Test error when label doesn't immediately precede DEVEC

### DIFF
--- a/trillium/test/devec_label_error_scalar.s
+++ b/trillium/test/devec_label_error_scalar.s
@@ -1,0 +1,26 @@
+; ARGS: devec_label_error_vector.s
+; RETURN: 1
+
+SCALAR_HEADER
+tril_somefunc:
+	BEFORE_VECTOR_EPOCH
+	.insn i 0x77, 0, x0, a0, 0x401
+.L1:
+	SCALAR_BEFORE_DEVEC
+	.insn uj 0x2b, x0, .L14
+.L2:
+	SCALAR_AFTER_DEVEC
+	trillium vissue_delim return scalar_return
+  SCALAR_STACK_CLEANUP
+  ret
+  SCALAR_AFTER_RETURN
+.L3:
+	trillium glue_point block_one
+.L4:
+  AN_AUXILIARY_BLOCK
+.L5:
+	trillium glue_point block_two
+.L6:
+  ANOTHER_AUXILIARY_BLOCK
+.size whatever
+SCALAR_FOOTER

--- a/trillium/test/devec_label_error_vector.s
+++ b/trillium/test/devec_label_error_vector.s
@@ -1,0 +1,18 @@
+VECTOR_HEADER
+somefunc:
+	TRILLIUM_INIT_BLOCK
+  .L1:
+	trillium vissue_delim begin block_one
+  .L2:
+  VECTOR_BLOCK_ONE
+  .L3:
+	trillium vissue_delim end
+  .L4:
+  VECTOR_AFTER_BLOCK_ONE
+  .L5:
+	trillium vissue_delim return block_two
+  .L6:
+  VECTOR_BLOCK_TWO
+  ret
+.size whatever
+VECTOR_FOOTER


### PR DESCRIPTION
Test located at `trillium/test/devec_label_error_scalar.s`