### PR TITLE
Fix common Makefile handling of global objects

### DIFF
--- a/programs-phil/spad/common/common.mk
+++ b/programs-phil/spad/common/common.mk
@@ -21,11 +21,16 @@ RV_CC=/data/phil/riscv-rv64g/bin/riscv64-unknown-linux-gnu-gcc
 
 CFLAGS=-D_N_SPS=$(N_SPS) $(EXTRA_FLAGS) -O3 --std=gnu11 -static -I../common/ -T../common/spm.ld -lpthread -lm
 
-C_SRCS_NOKERN := $(filter-out $(TRILLIASM_KERNEL), $(wildcard *.c)) $(wildcard ../common/*.c)
+C_SRCS_NOKERN := $(filter-out $(TRILLIASM_KERNEL), $(wildcard *.c))
 C_DEPS_NOKERN := $(C_SRCS_NOKERN:.c=.o)
 
-$(BENCHNAME) : $(TRILLIASM_OBJS) $(C_DEPS_NOKERN)
-	$(RV_CC) $(TRILLIASM_OBJS) $(C_DEPS_NOKERN) $(CFLAGS) -o $@
+# Build common libraries, but build them "locally" (in this directory) so
+# they get updated according to this benchmark's configuration.
+COMMON_SRCS := $(wildcard $(COMMON_DIR)/*.c)
+COMMON_OBJS := $(notdir $(COMMON_SRCS:.c=.o))
+
+$(BENCHNAME) : $(TRILLIASM_OBJS) $(C_DEPS_NOKERN) $(COMMON_OBJS)
+	$(RV_CC) $(TRILLIASM_OBJS) $(C_DEPS_NOKERN) $(COMMON_OBJS) $(CFLAGS) -o $@
 
 run: $(BENCHNAME)
 	$(BASE_DIR)/build/RVSP/gem5.opt \
@@ -36,8 +41,11 @@ run: $(BENCHNAME)
 	--num-cpus=$(N_SPS) \
 	--vector
 
-$(C_DEPS_NOKERN): %.o : %.c
-	$(RV_CC) $(CFLAGS) -c $^ -o $(notdir $@)
+$(C_DEPS_NOKERN): %.o: %.c
+	$(RV_CC) $(CFLAGS) -c $^ -o $@
+
+$(COMMON_OBJS): %.o: $(COMMON_DIR)/%.c
+	$(RV_CC) $(CFLAGS) -c $^ -o $@
 
 clean:
 	rm -rf *.o *.s $(BENCHNAME) m5out


### PR DESCRIPTION
The distinction between `C_DEPS_NOKERN` (.o files in the current directory) and `C_OBJS_NOKERN` (.o files in the `common` directory) was causing the gcc invocation to look for the objects in the wrong directory, leading to this error:

```
/data/phil/riscv-rv64g/bin/riscv64-unknown-linux-gnu-gcc vvadd_kernel.o main.o vvadd.o pthread_launch.o spad.o group_templates.o -D_N_SPS=64  -O3 --std=gnu11 -static -I../common/ -T../common/spm.ld -lpthread -lm -o vvadd
riscv64-unknown-linux-gnu-gcc: error: pthread_launch.o: No such file or directory
riscv64-unknown-linux-gnu-gcc: error: spad.o: No such file or directory
riscv64-unknown-linux-gnu-gcc: error: group_templates.o: No such file or directory
```

Because these files were implicitly built in the `common` directory, not in the benchmark directory. Introduced in #39, AFAICT.