### PR TITLE
Common Makefile: avoid hard-coding the repository directory

### DIFF
--- a/programs-phil/spad/common/common.mk
+++ b/programs-phil/spad/common/common.mk
@@ -12,6 +12,10 @@ ifneq ($(ENV_EXTRA_MAKE_FLAGS),)
 	EXTRA_FLAGS := $(EXTRA_FLAGS) $(ENV_EXTRA_MAKE_FLAGS)
 endif
 
+# Find the repository's base directory.
+COMMON_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+BASE_DIR := $(COMMON_DIR)/../../..
+
 # installed cross compiler gcc for riscv
 RV_CC=/data/phil/riscv-rv64g/bin/riscv64-unknown-linux-gnu-gcc
 
@@ -24,10 +28,10 @@ C_OBJS_NOKERN := $(notdir $(C_SRCS_NOKERN:.c=.o))
 $(BENCHNAME) : $(TRILLIASM_OBJS) $(C_DEPS_NOKERN)
 	$(RV_CC) $(TRILLIASM_OBJS) $(C_OBJS_NOKERN) $(CFLAGS) -o $@
 
-run : $(BENCHNAME)
-	~/gem5-mesh/build/RVSP/gem5.opt \
+run: $(BENCHNAME)
+	$(BASE_DIR)/build/RVSP/gem5.opt \
 	--remote-gdb-port=0 \
-	~/gem5-mesh/configs/phil/brg_hammerblade.py \
+	$(BASE_DIR)/configs/phil/brg_hammerblade.py \
 	--cmd=$(BENCHNAME) \
 	--options="" \
 	--num-cpus=$(N_SPS) \


### PR DESCRIPTION
The `make run` target used to require that the repository be located at `~/gem5-mesh`. Now it uses a relative directory so it can be located anywhere. (I've been keeping mine in `/data` on Gorgonzola, for example.)