### PR TITLE
Trilliasm Makefile improvements

### DIFF
--- a/programs-phil/spad/atax/Makefile
+++ b/programs-phil/spad/atax/Makefile
@@ -8,10 +8,9 @@ N_SPS ?= 16  # This benchmark expects 16 CPUs for now.
 GEM5_ARGS := -d ../../../results/$(OUT)
 HB_ARGS := --options="$(SIZE) $(SIZE)"
 
-#plug in trilliasm make recipes
-TRILLIASM_KERNEL = atax_kernel.c
-TRILLIUM_DIR=../../../trillium
-include $(TRILLIUM_DIR)/trilliasm.mk
+# Build the kernel with trilliasm.
+TRILLIASM_KERNEL := atax_kernel.c
+include ../../../trillium/trilliasm.mk
 
-# run standard compilation
+# Standard benchmark compilation.
 include ../common/common.mk

--- a/programs-phil/spad/if-delim-test/Makefile
+++ b/programs-phil/spad/if-delim-test/Makefile
@@ -1,12 +1,11 @@
-BENCHNAME:=template
+BENCHNAME := if_test
 default: $(BENCHNAME)
 
-# plug in trilliasm make recipes
-TRILLIASM_KERNEL = if_test_kernel.c
-TRILLIUM_DIR=../../../trillium
-include $(TRILLIUM_DIR)/trilliasm.mk
+# Build the kernel with trilliasm.
+TRILLIASM_KERNEL := if_test_kernel.c
+include ../../../trillium/trilliasm.mk
 
-# run standard compilation
+# Standard benchmark compilation.
 include ../common/common.mk
 
 # specify number of cpus (TODO: rename to NUM_CPUS)

--- a/programs-phil/spad/template_benchmark/Makefile
+++ b/programs-phil/spad/template_benchmark/Makefile
@@ -1,14 +1,12 @@
-BENCHNAME:=template
+BENCHNAME := template
 default: $(BENCHNAME)
 
-# plug in trilliasm make recipes
-TRILLIASM_KERNEL = template_kernel.c
-TRILLIUM_DIR=../../../trillium
-include $(TRILLIUM_DIR)/trilliasm.mk
+# Build the kernel with trilliasm.
+TRILLIASM_KERNEL := template_kernel.c
+include ../../../trillium/trilliasm.mk
 
-# run standard compilation
-COMMON_DIR=../common
-include $(COMMON_DIR)/common.mk
+# Standard benchmark compilation.
+include ../common/common.mk
 
-# specify number of cpus (TODO: rename to NUM_CPUS)
-N_SPS=16
+# Specify number of CPUs. (TODO: rename to NUM_CPUS)
+N_SPS := 16

--- a/programs-phil/spad/vvadd/Makefile
+++ b/programs-phil/spad/vvadd/Makefile
@@ -1,11 +1,9 @@
-BENCHNAME:=vvadd
+BENCHNAME := vvadd
 default: $(BENCHNAME)
 
-#plug in trilliasm make recipes
-TRILLIASM_KERNEL = vvadd_kernel.c
-TRILLIUM_DIR=../../../trillium
-include $(TRILLIUM_DIR)/trilliasm.mk
+# Build the kernel with trilliasm.
+TRILLIASM_KERNEL := vvadd_kernel.c
+include ../../../trillium/trilliasm.mk
 
-# run standard compilation
-COMMON_DIR=../common
-include $(COMMON_DIR)/common.mk
+# Standard benchmark compilation.
+include ../common/common.mk

--- a/trillium/trilliasm.mk
+++ b/trillium/trilliasm.mk
@@ -1,32 +1,27 @@
-#This Makefile fragment generates rules for building a Trilliasm kernel.
-#To use, you must specify the name of the Trilliasm kernel file:
-#TRILLIASM_KERNEL= name of the trilliasm kernel used in benchmark (e.g.: vvadd_kernel.c)
+# This Makefile fragment inclues rules for building a Trilliasm kernel.
+# To use, you must specify the name of the Trilliasm kernel source file,
+# and then include this file:
+#
+#     TRILLIASM_KERNEL := mybench_kernel.c
+# 	  include ../../../trillium/trillium.mk
+#
+# Also be sure to define RV_CC and CFLAGS for the compilation rules.
+#
+# NOTE: to avoid clashing (%.o) targets with the $(KERNEL_NAME).o target,
+# replace rules of the form:
+# 	%.o: %.c
+# with:
+#  $(MY_NONKERNEL_OBJ_FILES): %.o: %.c
+# Those are "static pattern rules":
+# https://www.gnu.org/software/make/manual/html_node/Static-Usage.html#Static-Usage
 
-#In addition, `trilliasm.mk` needs the following bindings, for which defaults exist:
-#TRILLIUM_DIR= relative path to trillium directory (default: ../../../trillium)
-#COMMON_PATH= relative path to `common` folder with benchmark dependencies
-#RV_CC= path to RV compiler (default: /data/phil/riscv-rv64g/bin/riscv64-unknown-linux-gnu-gcc)
-#CFLAGS= flags to pass to RV_CC 
-
-#Then, include `trilliasm.mk` at the top of your Makefile:
-#include $(TRILLIUM_DIR)/trilliasm.mk
-
-#NOTE: to avoid clashing (%.o) targets with the $(KERNEL_NAME).o target, replace rules of the form:
-# %.o: %.c   with   $(MY_NONKERNEL_OBJ_FILES) : %.o: %.c
-#(i.e. Static Pattern Rules: https://www.gnu.org/software/make/manual/html_node/Static-Usage.html#Static-Usage)
-
-#NOTE: `trilliasm.mk` internally uses KERNEL_NAME to strip the path and file extension from TRILLIASM_KERNEL
-#I'm not good enough at Makefiles yet to know for sure if you can break `trilliasm.mk` by rebinding that variable, so beware
-
-TRILLIUM_DIR?=../../../trillium
-COMMON_PATH?=../common
-RV_CC?=/data/phil/riscv-rv64g/bin/riscv64-unknown-linux-gnu-gcc
-CFLAGS?=-D_N_SPS=16 -O3 fno-reorder-blocks --std=gnu11 -static -I$(COMMON_PATH) -T$(COMMON_PATH)/spm.ld -lpthread -lm
+# Ensure that RV_CC and CFLAGS are set (we do not define them here). These
+# extra flags apply only to compiling the vector "half" of the code.
 VECTOR_CFLAGS ?= -fno-reorder-blocks
 
-
-KERNEL_NAME:= $(basename $(TRILLIASM_KERNEL))
-TRILLIASM_OBJS=$(TRILLIASM_KERNEL:.c=.o)
+TRILLIUM_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+KERNEL_NAME := $(basename $(TRILLIASM_KERNEL))
+TRILLIASM_OBJS := $(TRILLIASM_KERNEL:.c=.o)
 
 $(KERNEL_NAME)_vector.s: $(KERNEL_NAME).c
 	$(RV_CC) $(VECTOR_CFLAGS) $(CFLAGS) -D VECTOR_CORE -S $< -o $@


### PR DESCRIPTION
Just a little TLC for the Trilliasm Makefile stuff, including the benchmark Makefiles that currently use it. Avoid some path wrangling stuff by looking up the current path to the Trillium directory. I also deleted some assignments to stuff like RV_CC that effectively need to be overridden anyway.

I'll merge now, but cc'ing @epeguero here just for fun, mostly. :smiley: