### PR TITLE
Disable GCC's tail duplication via `max-jump-thread-duplication-stmts`

### DIFF
--- a/trillium/trilliasm.mk
+++ b/trillium/trilliasm.mk
@@ -17,7 +17,8 @@
 
 # Ensure that RV_CC and CFLAGS are set (we do not define them here). These
 # extra flags apply only to compiling the vector "half" of the code.
-VECTOR_CFLAGS ?= -fno-reorder-blocks
+VECTOR_CFLAGS ?= -fno-reorder-blocks \
+	--param max-jump-thread-duplication-stmts=0
 
 TRILLIUM_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 KERNEL_NAME := $(basename $(TRILLIASM_KERNEL))


### PR DESCRIPTION
This seems to be the magic incantation that stops the kind of code duplication that -O3 was enabling. 💀 