### PR TITLE
Fix bug with NOACK reqs 

### DIFF
--- a/src/mem/ruby/scratchpad/Scratchpad.cc
+++ b/src/mem/ruby/scratchpad/Scratchpad.cc
@@ -723,7 +723,12 @@ Scratchpad::handleCpuReq(Packet* pkt_p)
       msg_p->m_Requestor = m_machineID;
       msg_p->m_MessageSize = MessageSizeType_Request_Control;
       (msg_p->m_Destination).add(dst_port);
-      msg_p->m_SeqNum = m_cur_seq_num;
+      
+      if (noLLCAck)
+        msg_p->m_SeqNum = -1;
+      else
+        msg_p->m_SeqNum = m_cur_seq_num;
+
       // access length in x,y -- prob always linearized
       msg_p->m_XDim = pkt_p->getXDim();
       msg_p->m_YDim = pkt_p->getYDim();


### PR DESCRIPTION
Fix issue where noacked was getting assigned a request seq num that was still in pending req buffer and erroneously absorbing an ack to that seq num. fix by assigning dummy value at request time.