### PR TITLE
Try using exit(1) after every glue point

### DIFF
--- a/programs-spad/covar/covar_kernel.c
+++ b/programs-spad/covar/covar_kernel.c
@@ -469,16 +469,22 @@ void tril_covar(int mask, DTYPE *symmat, DTYPE *data, int N, int M,
 #ifdef SCALAR_CORE
 init_label:
   asm("trillium glue_point vector_init");
+  exit(1);
 vec_body_init_label:
   asm("trillium glue_point vec_body_init");
+  exit(1);
 vec_body_label:
   asm("trillium glue_point vec_body");
+  exit(1);
 vec_body_end_label:
   asm("trillium glue_point vec_body_end");
+  exit(1);
 j2_end_label:
   asm("trillium glue_point j2_end");
+  exit(1);
 vector_return_label:
   asm("trillium glue_point vector_return");
+  exit(1);
 #endif
 
 


### PR DESCRIPTION
This is a semi-silly hack to avoid a problem @pbb59 was seeing where glue points were being duplicated. The root cause is that GCC was trying to follow control flow paths that went "through" the glue point, i.e., would allow code to fall through from one glue point to the next. There was an added complication occurring when GCC tried to interpret a vissue instruction as "branch-like" and therefore as a traversable control flow edge from the vissue to the glue point—and then on to the end.

My initial idea was just to add `return` after every glue point, to signal to GCC that the program will never to "fall through" to the next glue point. This *mostly* worked, except for the `vector_return` glue point, which still got duplicated. This was super rough to figure out but the problem turned out to be that GCC was generating an "early exit" for a condition when the outer loop was guaranteed to run zero times. In this case, there is no stack cleanup to be done (because nothing has been allocated on the stack yet!). So it needed an extra copy of the `vector_return` vissue that didn't include stack cleanup stuff, and that came with an extra copy of the corresponding glue point (again because of vissues getting interpreted as control flow).

So this solution is similar except it just `exit(1)`s to abort execution entirely without even bothering to do stack cleanup. The point is that any CFG path that GCC imagines going from a vissue to a glue point will abruptly stop right there—it will not continue on to other glue points, it will not try to return from the function, it will not pass "go" nor collect $200. So there is no need to create separate variants of the glue points. And indeed, the effect is that the duplication goes away.

With #73, the exit calls will be deleted entirely from the output code. Even without that, they are ineffectual (never executed). If this works, I'll edit the wiki to recommend `exit(1)` after every glue point.