### PR TITLE
fix issue with frames in vvadd

### DIFF
--- a/programs-spad/vvadd/vvadd.h
+++ b/programs-spad/vvadd/vvadd.h
@@ -41,6 +41,7 @@
 
 // prefetch sizings
 #define POST_REGION_WORD 512
+#define INIT_FRAMES 1
 #if defined(VERTICAL_LOADS) || defined(SPATIAL_UNROLL)
 // load 16 words (whole cacheline at a time)
 #define LOAD_LEN 16

--- a/programs-spad/vvadd/vvadd_kernel.c
+++ b/programs-spad/vvadd/vvadd_kernel.c
@@ -110,13 +110,12 @@ inline void vvadd_body(DTYPE *spadAddr, DTYPE **cPtr, int *sp, int dim) {
 void tril_vvadd(int mask, DTYPE *a, DTYPE *b, DTYPE *c, int start, int end, int ptid, int vtid, int dim, int is_master)
 {
 
+  int prefetchFrames = INIT_FRAMES; // BE carful about prefetching, this + queue size >= num hardware frames
 
   #if defined(VERTICAL_LOADS) || defined(SPATIAL_UNROLL)
-  int prefetchFrames = 12; // BE carful about prefetching, this + queue size >= num hardware frames
   int numInitFetch = LOAD_LEN * prefetchFrames;
   int step = LOAD_LEN;
   #else
-  int prefetchFrames = 16;
   int numInitFetch = prefetchFrames;
   int step = 1;
   #endif


### PR DESCRIPTION
VVADD was initially prefetching too many frames to be synced. Fixed by setting to 1 (from 16). Started failing recently because got stricter about failures here.